### PR TITLE
Align `controlled_frame` field in feedback with design

### DIFF
--- a/action/FollowCartesianTrajectory.action
+++ b/action/FollowCartesianTrajectory.action
@@ -19,7 +19,7 @@ string error_string
 ---
 
 Header header
-string tcp_frame
+string controlled_frame
 CartesianTrajectoryPoint desired
 CartesianTrajectoryPoint actual
 CartesianTrajectoryPoint error


### PR DESCRIPTION
Discussion: #6.

`tcp_frame` was the old name, before it got renamed to `controlled_frame`.

The [the design document](https://github.com/fzi-forschungszentrum-informatik/fzi_robot_interface_proposal/blob/01a9c14a456fb76ccc6dd158a9cb0573a9ebb2da/source/proposal/index.rst#L237) does list it as `controlled_frame`, so this corrects the mistake in the `.action` definition.
